### PR TITLE
fix: overloaded function handling with signatures

### DIFF
--- a/src/apicov.py
+++ b/src/apicov.py
@@ -303,16 +303,43 @@ def main():
     with open(api_file, "w") as fh:
         json.dump(json_data, fh, indent=2)
 
-    # Build list of simple API names for Coverage module (backward compatible)
-    # Coverage.py uses simple names for gcov matching
-    all_apis = []
+    def normalize_signature(sig: str) -> str:
+        """Normalize C++ signature for consistent matching.
+
+        Converts "char const*" to "const char*" format and removes extra spaces.
+        This ensures consistent matching between header-extracted signatures
+        and gcov demangled names.
+        """
+        import re
+        # "char const*" -> "const char*"
+        sig = re.sub(r'(\w+)\s+const\s*([*&])', r'const \1\2', sig)
+        # Remove spaces around * and &
+        sig = re.sub(r'\s*([*&])\s*', r'\1', sig)
+        return sig
+
+    # Build list of API names for Coverage module
+    # For C++ overloaded functions, use full_name (qualified + signature) to uniquely identify
+    # For C functions (no signature), use the simple name
+    all_apis = []  # Full names for coverage lookup
+    simple_api_names = []  # Simple names for Doxygen documentation lookup
     for file, apis in lib_exports.apis.items():
         for api in apis:
             # Handle both old format (string) and new format (dict)
             if isinstance(api, dict):
-                all_apis.append(api["simple"])
+                qualified_name = api["qualified"]
+                simple_name = api["simple"]
+                signature = api.get("signature", "")
+                # Normalize signature for consistent matching with gcov output
+                if signature:
+                    signature = normalize_signature(signature)
+                # Build full_name for unique identification of overloaded functions
+                full_name = qualified_name + signature if signature else qualified_name
+                all_apis.append(full_name)
+                simple_api_names.append(simple_name)
             else:
+                # Backward compatibility: old format was just a string (C functions)
                 all_apis.append(api)
+                simple_api_names.append(api)
     entry_cov = LibCoverage(all_apis, project_dir)
     logging.debug("DEBUG: Running gcov to identify API sizes and coverage")
     entry_cov.run_gcov_on_gcno_files()
@@ -322,7 +349,8 @@ def main():
         logging.info("Doxygen path provided, generating API documentation")
         doxygen_path = os.path.abspath(os.path.expanduser(args.doxygen_path))
         doc_gen = DocGen(doxygen_path, xml=args.xml)
-        apidoc = doc_gen.generate_apidoc(all_apis)
+        # Use simple_api_names for Doxygen - it only stores simple function names
+        apidoc = doc_gen.generate_apidoc(simple_api_names)
     else:
         logging.info("No Doxygen path provided, skipping API documentation generation")
         apidoc = None
@@ -338,32 +366,39 @@ def main():
                 qualified_name = api["qualified"]
                 simple_name = api["simple"]
                 signature = api.get("signature", "")
+                # Normalize signature for consistent matching with gcov output
+                if signature:
+                    signature = normalize_signature(signature)
             else:
                 # Backward compatibility: old format was just a string
                 qualified_name = api
                 simple_name = api
                 signature = ""
 
-            # Use qualified name as the key in the output JSON
-            # This allows distinguishing between methods with same name in different classes
-            json_data[file][qualified_name] = {
+            # Build full_name for coverage lookup (matches what LibCoverage uses)
+            full_name = qualified_name + signature if signature else qualified_name
+
+            # Use full_name as the key in the output JSON
+            # This allows distinguishing between overloaded functions with same qualified name
+            # e.g., Json::PathArgument::PathArgument(char const*) vs PathArgument(unsigned int)
+            json_data[file][full_name] = {
                 "simple_name": simple_name,  # Include simple name for reference
                 "signature": signature,  # Include signature
                 "full_size": 0,
                 "covered_lines": 0
             }
 
-            # Coverage data is keyed by simple name (from LibCoverage)
-            if simple_name in entry_cov.api_sizes:
-                json_data[file][qualified_name]["full_size"] = entry_cov.api_sizes[simple_name]
-                json_data[file][qualified_name]["covered_lines"] = entry_cov.api_coverage[simple_name]
+            # Coverage data is keyed by full_name (qualified + signature)
+            if full_name in entry_cov.api_sizes:
+                json_data[file][full_name]["full_size"] = entry_cov.api_sizes[full_name]
+                json_data[file][full_name]["covered_lines"] = entry_cov.api_coverage[full_name]
             else:
-                logging.error("ERROR: Failed to find size for API: %s", simple_name)
-                no_cov_apis.append(simple_name)
+                logging.error("ERROR: Failed to find size for API: %s", full_name)
+                no_cov_apis.append(full_name)
 
-            # Documentation is also keyed by simple name
+            # Documentation is keyed by simple name (Doxygen uses simple names)
             if apidoc and simple_name in apidoc:
-                json_data[file][qualified_name]["apidoc"] = apidoc[simple_name]
+                json_data[file][full_name]["apidoc"] = apidoc[simple_name]
             else:
                 logging.debug("DEBUG: Failed to find documentation for API: %s", simple_name)
                 no_doc_apis.append(simple_name)

--- a/src/apicov.py
+++ b/src/apicov.py
@@ -311,8 +311,12 @@ def main():
         and gcov demangled names.
         """
         import re
-        # "char const*" -> "const char*"
-        sig = re.sub(r'(\w+)\s+const\s*([*&])', r'const \1\2', sig)
+        # "char const*" -> "const char*", handles namespaced/multi-word types
+        sig = re.sub(
+            r'([A-Za-z_][\w:<>]*(?:\s+[A-Za-z_][\w:<>]*)*)\s+const\s*([*&])',
+            r'const \1\2',
+            sig,
+        )
         # Remove spaces around * and &
         sig = re.sub(r'\s*([*&])\s*', r'\1', sig)
         return sig
@@ -378,9 +382,8 @@ def main():
             full_name = qualified_name + signature if signature else qualified_name
 
             json_data[file][full_name] = {
-                "name": qualified_name,
+                "name": full_name,
                 "simple_name": simple_name,
-                "signature": signature,
                 "full_size": 0,
                 "covered_lines": 0
             }

--- a/src/apicov.py
+++ b/src/apicov.py
@@ -375,20 +375,16 @@ def main():
                 simple_name = api
                 signature = ""
 
-            # Build full_name for coverage lookup (matches what LibCoverage uses)
             full_name = qualified_name + signature if signature else qualified_name
 
-            # Use full_name as the key in the output JSON
-            # This allows distinguishing between overloaded functions with same qualified name
-            # e.g., Json::PathArgument::PathArgument(char const*) vs PathArgument(unsigned int)
             json_data[file][full_name] = {
-                "simple_name": simple_name,  # Include simple name for reference
-                "signature": signature,  # Include signature
+                "name": qualified_name,
+                "simple_name": simple_name,
+                "signature": signature,
                 "full_size": 0,
                 "covered_lines": 0
             }
 
-            # Coverage data is keyed by full_name (qualified + signature)
             if full_name in entry_cov.api_sizes:
                 json_data[file][full_name]["full_size"] = entry_cov.api_sizes[full_name]
                 json_data[file][full_name]["covered_lines"] = entry_cov.api_coverage[full_name]
@@ -396,7 +392,6 @@ def main():
                 logging.error("ERROR: Failed to find size for API: %s", full_name)
                 no_cov_apis.append(full_name)
 
-            # Documentation is keyed by simple name (Doxygen uses simple names)
             if apidoc and simple_name in apidoc:
                 json_data[file][full_name]["apidoc"] = apidoc[simple_name]
             else:

--- a/src/modules/ClangParser.py
+++ b/src/modules/ClangParser.py
@@ -8,6 +8,8 @@ and extract qualified method names, signatures, and other API information.
 from dataclasses import dataclass
 from typing import Optional
 import logging
+import platform
+import subprocess
 
 try:
     import clang.cindex
@@ -53,12 +55,92 @@ class ClangParser:
             '-std=c++17',
         ]
 
+        # Add system include paths (platform-specific)
+        self.default_args.extend(self._get_system_include_paths())
+
         # Add include directories
         for header_dir in self.header_dirs:
             self.default_args.append(f'-I{header_dir}')
 
         # Add user-specified flags
         self.default_args.extend(self.compile_flags)
+
+    def _get_system_include_paths(self) -> list[str]:
+        """Get system include paths for C++ standard library."""
+        import os
+        import glob
+        paths = []
+
+        if platform.system() == 'Darwin':
+            try:
+                sdk_path = subprocess.check_output(
+                    ['xcrun', '--show-sdk-path'],
+                    stderr=subprocess.DEVNULL
+                ).decode().strip()
+
+                cxx_include = f"{sdk_path}/usr/include/c++/v1"
+                c_include = f"{sdk_path}/usr/include"
+
+                # C++ stdlib must come before clang builtins and C stdlib
+                paths.extend(['-isystem', cxx_include])
+
+                # Find clang's built-in headers (needed for stdarg.h, etc.)
+                clang_builtin_paths = [
+                    '/opt/homebrew/Cellar/llvm/*/lib/clang/*/include',
+                    '/usr/local/Cellar/llvm/*/lib/clang/*/include',
+                ]
+                for pattern in clang_builtin_paths:
+                    matches = sorted(glob.glob(pattern), reverse=True)
+                    for p in matches:
+                        if os.path.isdir(p):
+                            paths.extend(['-isystem', p])
+                            break
+                    if len(paths) > 2:
+                        break
+
+                paths.extend(['-isystem', c_include])
+            except Exception as e:
+                logging.debug(f"Could not get macOS SDK path: {e}")
+
+        elif platform.system() == 'Linux':
+            import struct
+            arch = 'aarch64' if struct.calcsize('P') * 8 == 64 and platform.machine() == 'aarch64' else 'x86_64'
+
+            # Find GCC version and C++ headers
+            gcc_versions = sorted(glob.glob('/usr/include/c++/*'), reverse=True)
+            for gcc_path in gcc_versions:
+                if os.path.isdir(gcc_path):
+                    paths.extend(['-isystem', gcc_path])
+                    # Platform-specific C++ headers
+                    arch_path = f"{gcc_path}/{arch}-linux-gnu"
+                    if os.path.isdir(arch_path):
+                        paths.extend(['-isystem', arch_path])
+                    break
+
+            # GCC internal headers (where cstdlib finds stdlib.h)
+            gcc_internal = sorted(glob.glob(f'/usr/lib/gcc/{arch}-linux-gnu/*/include'), reverse=True)
+            for p in gcc_internal:
+                if os.path.isdir(p):
+                    paths.extend(['-isystem', p])
+                    break
+
+            # Clang's builtin headers
+            clang_builtin_paths = [
+                '/usr/lib/llvm-*/lib/clang/*/include',
+                '/usr/lib/clang/*/include',
+            ]
+            for pattern in clang_builtin_paths:
+                matches = sorted(glob.glob(pattern), reverse=True)
+                for p in matches:
+                    if os.path.isdir(p):
+                        paths.extend(['-isystem', p])
+                        break
+
+            # Standard C include path
+            if os.path.isdir('/usr/include'):
+                paths.extend(['-isystem', '/usr/include'])
+
+        return paths
 
     def parse_header(self, header_path: str) -> dict[str, ApiInfo]:
         """

--- a/src/modules/ClangParser.py
+++ b/src/modules/ClangParser.py
@@ -143,19 +143,25 @@ class ClangParser:
         if cursor.kind == CursorKind.FUNCTION_DECL:
             api_info = self._extract_function_info(cursor, namespace_stack, target_file)
             if api_info and api_info.is_public:
-                apis[api_info.qualified_name] = api_info
+                # Use full name with signature as key to support overloaded functions
+                full_key = api_info.qualified_name + (api_info.signature or "")
+                apis[full_key] = api_info
 
         # Extract method declarations
         elif cursor.kind == CursorKind.CXX_METHOD:
             api_info = self._extract_method_info(cursor, namespace_stack, target_file)
             if api_info and api_info.is_public:
-                apis[api_info.qualified_name] = api_info
+                # Use full name with signature as key to support overloaded methods
+                full_key = api_info.qualified_name + (api_info.signature or "")
+                apis[full_key] = api_info
 
         # Extract constructors
         elif cursor.kind == CursorKind.CONSTRUCTOR:
             api_info = self._extract_constructor_info(cursor, namespace_stack, target_file)
             if api_info and api_info.is_public:
-                apis[api_info.qualified_name] = api_info
+                # Use full name with signature as key to support overloaded constructors
+                full_key = api_info.qualified_name + (api_info.signature or "")
+                apis[full_key] = api_info
 
         # Recurse into other children
         for child in cursor.get_children():

--- a/src/modules/Coverage.py
+++ b/src/modules/Coverage.py
@@ -83,8 +83,18 @@ class LibCoverage:
                    of executed lines and total_lines is the total number of lines
         """
         logging.debug("DEBUG: Processing function: %s", fn)
-        cmd = ["grep", "-A1", "-rw", fn, "--include=*.gcov_log", self._root_dir]
+        # Use -F for fixed string matching (handles special chars like * in signatures)
+        cmd = ["grep", "-A1", "-rF", fn, "--include=*.gcov_log", self._root_dir]
         results = subprocess.run(cmd, capture_output=True, text=True)
+
+        # If exact match fails, try searching by qualified name only (before signature)
+        # This handles cases where gcov uses different signature format (e.g., namespace-qualified param types)
+        if results.returncode != 0 and '(' in fn:
+            qualified_name = fn.split('(')[0]
+            logging.debug("DEBUG: Exact match failed, trying qualified name: %s", qualified_name)
+            cmd = ["grep", "-A1", "-rF", qualified_name, "--include=*.gcov_log", self._root_dir]
+            results = subprocess.run(cmd, capture_output=True, text=True)
+
         if results.returncode != 0:
             # logging.warning("Error - grep failed for function: %s", fn)
             return 0, 0
@@ -144,8 +154,18 @@ class LibCoverage:
         Args:
             api (str): API function name to calculate coverage for
         """
-        cmd = ["grep", "-A1", "-rw", api, "--include=*.gcov_log", self._root_dir]
+        # Use -F for fixed string matching (handles special chars like * in signatures)
+        cmd = ["grep", "-A1", "-rF", api, "--include=*.gcov_log", self._root_dir]
         results = subprocess.run(cmd, capture_output=True, text=True)
+
+        # If exact match fails, try searching by qualified name only (before signature)
+        # This handles cases where gcov uses different signature format (e.g., namespace-qualified param types)
+        if results.returncode != 0 and '(' in api:
+            qualified_name = api.split('(')[0]
+            logging.debug("DEBUG: Exact match failed for %s, trying qualified name: %s", api, qualified_name)
+            cmd = ["grep", "-A1", "-rF", qualified_name, "--include=*.gcov_log", self._root_dir]
+            results = subprocess.run(cmd, capture_output=True, text=True)
+
         for line in results.stdout.split("\n"):
             if "Cannot" in line:
                 continue
@@ -215,35 +235,45 @@ class LibCoverage:
                     gcno_files.append(os.path.join(root, file))
         return gcno_files
 
-    def _extract_function_name(self, name: str) -> tuple[str, str]:
+    def _extract_function_name(self, name: str) -> tuple[str, str, str]:
         """
-        Extract both qualified and simple function/method names from a potentially demangled C++ name.
+        Extract qualified name, simple name, and full name with signature from a potentially demangled C++ name.
 
         This method is backwards compatible with C code:
         - C functions pass through unchanged (no ::, no mangling)
-        - C++ demangled names are split into qualified and simple forms
+        - C++ demangled names are split into qualified, simple, and full forms
 
         Examples:
-            C:   'my_function' -> ('my_function', 'my_function')
-            C:   'SDL_Init' -> ('SDL_Init', 'SDL_Init')
-            C++: 'lok::Document::saveAs(char const*, char const*)' -> ('lok::Document::saveAs', 'saveAs')
-            C++: 'namespace::Class::method()' -> ('namespace::Class::method', 'method')
-            C++: 'std::vector<int>::push_back(int)' -> ('std::vector::push_back', 'push_back')
+            C:   'my_function' -> ('my_function', 'my_function', 'my_function')
+            C:   'SDL_Init' -> ('SDL_Init', 'SDL_Init', 'SDL_Init')
+            C++: 'lok::Document::saveAs(char const*)' -> ('lok::Document::saveAs', 'saveAs', 'lok::Document::saveAs(char const*)')
+            C++: 'Json::PathArgument::PathArgument(char const*)' -> ('Json::PathArgument::PathArgument', 'PathArgument', 'Json::PathArgument::PathArgument(char const*)')
+            C++: 'Json::PathArgument::PathArgument(unsigned int)' -> ('Json::PathArgument::PathArgument', 'PathArgument', 'Json::PathArgument::PathArgument(unsigned int)')
 
         Args:
             name (str): Function name (C) or demangled C++ function name
 
         Returns:
-            tuple[str, str]: (qualified_name, simple_name)
+            tuple[str, str, str]: (qualified_name, simple_name, full_name_with_signature)
                 qualified_name: Full namespace::Class::method without parameters
                 simple_name: Just the method name without namespace, class, or parameters
+                full_name_with_signature: Full name including signature for unique identification
         """
-        # For plain C functions without any special characters, return as-is for both
+        # For plain C functions without any special characters, return as-is for all three
         # This ensures backwards compatibility with C code
         if '::' not in name and '(' not in name and '<' not in name:
-            return (name, name)
+            return (name, name, name)
 
-        clean_name = re.sub(r'<[^>]*>', '', name)
+        # Keep the full name with signature (but strip templates)
+        full_name_with_signature = re.sub(r'<[^>]*>', '', name).strip()
+
+        # Normalize signature format for consistent matching between header-extracted signatures and gcov demangled names:
+        # 1. "char const*" -> "const char*"
+        full_name_with_signature = re.sub(r'(\w+)\s+const\s*([*&])', r'const \1\2', full_name_with_signature)
+        # Also normalize spacing around pointers/references
+        full_name_with_signature = re.sub(r'\s*([*&])\s*', r'\1', full_name_with_signature)
+
+        clean_name = full_name_with_signature
 
         # Find the last occurrence of '(' to separate function name from parameters
         # This handles cases like "(anonymous namespace)::function(params)"
@@ -262,7 +292,7 @@ class LibCoverage:
             if match:
                 operator_name = match.group(1)
                 # For qualified, keep full path to operator
-                return (qualified_name, operator_name)
+                return (qualified_name, operator_name, full_name_with_signature)
 
         # Get the last component after :: for simple name
         simple_name = qualified_name
@@ -274,7 +304,7 @@ class LibCoverage:
             # Fallback to qualified name or original input
             simple_name = qualified_name if qualified_name else name.split('(')[0] if '(' in name else name
 
-        return (qualified_name, simple_name)
+        return (qualified_name, simple_name, full_name_with_signature)
 
     def demangle_cxx_names(self, text: str) -> str:
         """
@@ -300,8 +330,12 @@ class LibCoverage:
             return text
 
         try:
+            # Use -n (no-strip-underscore) flag for cross-platform compatibility.
+            # macOS prepends underscores to symbols; without -n, c++filt may strip
+            # the leading underscore from _Z... mangled names and fail to demangle.
+            # On Linux x86_64, -n is a no-op since no extra underscores are added.
             result = subprocess.run(
-                ["c++filt"],
+                ["c++filt", "-n"],
                 input=text,
                 capture_output=True,
                 text=True,
@@ -311,15 +345,19 @@ class LibCoverage:
                 logging.warning("c++filt failed, using original text")
                 return text
 
-            # Process each line and simplify demangled names to just function names
+            # Process each line - preserve full demangled names with signatures
+            # This allows distinguishing overloaded functions like:
+            #   Json::PathArgument::PathArgument(char const*)
+            #   Json::PathArgument::PathArgument(unsigned int)
+            # The full_name_with_signature is used as the key for coverage lookup
             output_lines = []
             for line in result.stdout.splitlines():
                 if line.startswith("Function '") and line.endswith("'"):
                     # Extract the demangled name
                     demangled = line[10:-1]  # Remove "Function '" and trailing "'"
-                    qualified_name, simple_name = self._extract_function_name(demangled)
-                    # For gcov matching, use simple_name (backward compatible)
-                    output_lines.append(f"Function '{simple_name}'")
+                    qualified_name, simple_name, full_name = self._extract_function_name(demangled)
+                    # Use full_name (includes signature) for unique identification of overloads
+                    output_lines.append(f"Function '{full_name}'")
                 else:
                     output_lines.append(line)
 

--- a/src/modules/Coverage.py
+++ b/src/modules/Coverage.py
@@ -1,3 +1,4 @@
+import math
 import os
 import re
 import subprocess
@@ -175,7 +176,8 @@ class LibCoverage:
                 size = int(t.split("of")[-1].strip())
                 # logging.debug("Coverage string: %s", coverage.strip("%"))
                 float_cov = float(coverage.strip("%"))
-                # logging.debug("Float value: %r", float_cov)
+                if math.isnan(float_cov):
+                    float_cov = 0.0
                 if float_cov > 100.00:
                     logging.debug("DEBUG: Coverage greater than 100%")
                     logging.debug("DEBUG: %s", results.stdout)

--- a/tests/test_apicov_integration.py
+++ b/tests/test_apicov_integration.py
@@ -107,20 +107,21 @@ namespace MyLib {
                 qualified_name = api["qualified"]
                 simple_name = api["simple"]
                 signature = api.get("signature", "")
+                full_name = qualified_name + signature if signature else qualified_name
 
-                json_data[file][qualified_name] = {
+                json_data[file][full_name] = {
+                    "name": full_name,
                     "simple_name": simple_name,
-                    "signature": signature,
                     "full_size": 0,
                     "covered_lines": 0
                 }
 
         # Verify structure
         for file, api_dict in json_data.items():
-            for qualified_name, api_data in api_dict.items():
+            for api_key, api_data in api_dict.items():
                 # Each API should have these fields
+                assert "name" in api_data
                 assert "simple_name" in api_data
-                assert "signature" in api_data
                 assert "full_size" in api_data
                 assert "covered_lines" in api_data
 
@@ -310,7 +311,6 @@ class TestBackwardCompatibilityHandling:
         api_data = {
             "name": "oldFunction",
             "simple_name": None,
-            "signature": None
         }
 
         # Code should fallback to name

--- a/tests/test_clang_parser.py
+++ b/tests/test_clang_parser.py
@@ -100,8 +100,9 @@ namespace MyNamespace {
 
         apis = parser.parse_header(header_path)
 
-        assert "MyNamespace::simpleFunction" in apis
-        api_info = apis["MyNamespace::simpleFunction"]
+        # Keys now include signature to support overloaded functions
+        assert "MyNamespace::simpleFunction(int)" in apis
+        api_info = apis["MyNamespace::simpleFunction(int)"]
         assert api_info.simple_name == "simpleFunction"
         assert api_info.qualified_name == "MyNamespace::simpleFunction"
         assert api_info.signature == "(int)"
@@ -125,15 +126,17 @@ namespace MyNamespace {
 
         apis = parser.parse_header(header_path)
 
-        # Should have public methods
-        assert "MyNamespace::MyClass::publicMethod" in apis
-        assert "MyNamespace::MyClass::getNumber" in apis
+        # Should have public methods (keys include signature)
+        # Note: libclang may add spaces in signatures, so check flexibly
+        assert any("MyNamespace::MyClass::publicMethod" in k for k in apis)
+        assert "MyNamespace::MyClass::getNumber()" in apis
 
         # Should NOT have private methods
-        assert "MyNamespace::MyClass::privateMethod" not in apis
+        assert not any("privateMethod" in k for k in apis)
 
         # Check public method details
-        public_method = apis["MyNamespace::MyClass::publicMethod"]
+        public_method_key = [k for k in apis if "publicMethod" in k][0]
+        public_method = apis[public_method_key]
         assert public_method.simple_name == "publicMethod"
         assert public_method.qualified_name == "MyNamespace::MyClass::publicMethod"
         assert public_method.is_public is True
@@ -153,8 +156,9 @@ namespace Outer {
 
         apis = parser.parse_header(header_path)
 
-        assert "Outer::Inner::nestedFunction" in apis
-        api_info = apis["Outer::Inner::nestedFunction"]
+        # Keys include signature
+        assert "Outer::Inner::nestedFunction()" in apis
+        api_info = apis["Outer::Inner::nestedFunction()"]
         assert api_info.simple_name == "nestedFunction"
 
     def test_parse_constructor(self, parser, temp_dir):
@@ -172,8 +176,9 @@ public:
 
         apis = parser.parse_header(header_path)
 
-        # Constructors should be detected
-        assert "MyClass::MyClass" in apis or "MyClass" in apis
+        # Constructors should be detected (keys include signature)
+        # Both overloaded constructors should be present
+        assert "MyClass::MyClass()" in apis or "MyClass::MyClass(int)" in apis
 
     def test_parse_template_class(self, parser, temp_dir):
         """Test parsing template classes (templates should have params erased)."""
@@ -216,12 +221,13 @@ namespace MyNamespace {
 
         apis = parser.parse_header(header_path)
 
-        assert "MyNamespace::ClassA::methodA" in apis
-        assert "MyNamespace::ClassB::methodB" in apis
+        # Keys include signature
+        assert "MyNamespace::ClassA::methodA()" in apis
+        assert "MyNamespace::ClassB::methodB()" in apis
 
         # Ensure they're different methods
-        assert apis["MyNamespace::ClassA::methodA"].simple_name == "methodA"
-        assert apis["MyNamespace::ClassB::methodB"].simple_name == "methodB"
+        assert apis["MyNamespace::ClassA::methodA()"].simple_name == "methodA"
+        assert apis["MyNamespace::ClassB::methodB()"].simple_name == "methodB"
 
     def test_parse_overloaded_methods(self, parser, temp_dir):
         """Test parsing overloaded methods (same name, different signatures)."""
@@ -291,8 +297,8 @@ void mainFunction();
 
         apis = parser.parse_header(header_path)
 
-        # Should only have mainFunction, not includedFunction
-        assert "mainFunction" in apis
+        # Should only have mainFunction, not includedFunction (keys include signature)
+        assert "mainFunction()" in apis
         # includedFunction might or might not be included depending on implementation
         # The key point is that we get at least the main file's APIs
 
@@ -334,13 +340,13 @@ void funcReference(const int& ref);
 
         apis = parser.parse_header(header_path)
 
-        # Check various signature formats
-        if "funcNoArgs" in apis:
-            assert "()" in apis["funcNoArgs"].signature
-        if "funcOneArg" in apis:
-            assert "int" in apis["funcOneArg"].signature
-        if "funcMultiArgs" in apis:
-            sig = apis["funcMultiArgs"].signature
+        # Check various signature formats (keys now include signature)
+        if "funcNoArgs()" in apis:
+            assert "()" in apis["funcNoArgs()"].signature
+        if "funcOneArg(int)" in apis:
+            assert "int" in apis["funcOneArg(int)"].signature
+        if "funcMultiArgs(const char*, int, float)" in apis:
+            sig = apis["funcMultiArgs(const char*, int, float)"].signature
             assert "char" in sig and "int" in sig and "float" in sig
 
     def test_public_private_detection(self, parser, temp_dir):
@@ -363,9 +369,9 @@ public:
 
         apis = parser.parse_header(header_path)
 
-        # Should have public methods
-        assert "MyClass::publicMethod1" in apis or "publicMethod1" in apis
-        assert "MyClass::publicMethod2" in apis or "publicMethod2" in apis
+        # Should have public methods (keys include signature)
+        assert "MyClass::publicMethod1()" in apis or "publicMethod1()" in apis
+        assert "MyClass::publicMethod2()" in apis or "publicMethod2()" in apis
 
         # Should NOT have private or protected methods
         private_count = sum(1 for name in apis.keys() if "privateMethod" in name)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -13,7 +13,7 @@ from modules.Coverage import LibCoverage
 
 
 class TestExtractFunctionName:
-    """Test the _extract_function_name method that returns (qualified, simple) tuples."""
+    """Test the _extract_function_name method that returns (qualified, simple, full_name) tuples."""
 
     @pytest.fixture
     def coverage(self, tmp_path):
@@ -23,55 +23,64 @@ class TestExtractFunctionName:
 
     def test_plain_c_function(self, coverage):
         """Test plain C function names pass through unchanged."""
-        qualified, simple = coverage._extract_function_name("my_function")
+        qualified, simple, full_name = coverage._extract_function_name("my_function")
         assert qualified == "my_function"
         assert simple == "my_function"
+        assert full_name == "my_function"
 
     def test_c_function_with_underscores(self, coverage):
         """Test C function with underscores."""
-        qualified, simple = coverage._extract_function_name("SDL_Init")
+        qualified, simple, full_name = coverage._extract_function_name("SDL_Init")
         assert qualified == "SDL_Init"
         assert simple == "SDL_Init"
+        assert full_name == "SDL_Init"
 
     def test_cpp_simple_qualified_name(self, coverage):
         """Test simple C++ qualified name namespace::function."""
-        qualified, simple = coverage._extract_function_name("MyNamespace::myFunction()")
+        qualified, simple, full_name = coverage._extract_function_name("MyNamespace::myFunction()")
         assert qualified == "MyNamespace::myFunction"
         assert simple == "myFunction"
+        assert full_name == "MyNamespace::myFunction()"
 
     def test_cpp_class_method(self, coverage):
         """Test C++ class method."""
-        qualified, simple = coverage._extract_function_name("MyClass::myMethod()")
+        qualified, simple, full_name = coverage._extract_function_name("MyClass::myMethod()")
         assert qualified == "MyClass::myMethod"
         assert simple == "myMethod"
+        assert full_name == "MyClass::myMethod()"
 
     def test_cpp_namespace_class_method(self, coverage):
         """Test C++ method with namespace and class."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "lok::Document::saveAs(char const*, char const*)"
         )
         assert qualified == "lok::Document::saveAs"
         assert simple == "saveAs"
+        # Signature is normalized: "char const*" -> "const char*"
+        assert full_name == "lok::Document::saveAs(const char*, const char*)"
 
     def test_cpp_nested_namespace(self, coverage):
         """Test nested namespace."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "Outer::Inner::Deep::function()"
         )
         assert qualified == "Outer::Inner::Deep::function"
         assert simple == "function"
+        assert full_name == "Outer::Inner::Deep::function()"
 
     def test_cpp_template_erased(self, coverage):
         """Test template parameters are erased."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "std::vector<int>::push_back(int)"
         )
         assert qualified == "std::vector::push_back"
         assert simple == "push_back"
+        # Templates are erased from full_name too
+        assert full_name == "std::vector::push_back(int)"
 
     def test_cpp_complex_template(self, coverage):
         """Test complex template parameters."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "MyClass<std::string, int>::method<double>()"
         )
         # Template parameters should be erased
@@ -80,55 +89,62 @@ class TestExtractFunctionName:
 
     def test_cpp_operator_overload(self, coverage):
         """Test operator overload."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "MyClass::operator<<(std::ostream&)"
         )
         # Should preserve operator
         assert "operator<<" in simple
         assert qualified == "MyClass::operator<<"
+        assert full_name == "MyClass::operator<<(std::ostream&)"
 
     def test_cpp_operator_plus(self, coverage):
         """Test operator+ overload."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "String::operator+(const String&)"
         )
         assert simple == "operator+"
         assert qualified == "String::operator+"
+        assert full_name == "String::operator+(const String&)"
 
     def test_no_parameters(self, coverage):
         """Test function without parentheses."""
-        qualified, simple = coverage._extract_function_name("namespace::Class::method")
+        qualified, simple, full_name = coverage._extract_function_name("namespace::Class::method")
         assert qualified == "namespace::Class::method"
         assert simple == "method"
+        assert full_name == "namespace::Class::method"
 
     def test_const_char_pointer_params(self, coverage):
         """Test parameters with const char*."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "MyClass::func(char const*, char const*, char const*)"
         )
         assert qualified == "MyClass::func"
         assert simple == "func"
+        # Signature is normalized: "char const*" -> "const char*"
+        assert full_name == "MyClass::func(const char*, const char*, const char*)"
 
     def test_reference_params(self, coverage):
         """Test parameters with references."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "MyClass::func(const std::string&, int&)"
         )
         assert qualified == "MyClass::func"
         assert simple == "func"
+        assert full_name == "MyClass::func(const std::string&, int&)"
 
     def test_pointer_params(self, coverage):
         """Test parameters with pointers."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "MyClass::func(int*, char**, void*)"
         )
         assert qualified == "MyClass::func"
         assert simple == "func"
+        assert full_name == "MyClass::func(int*, char**, void*)"
 
     def test_whitespace_variations(self, coverage):
         """Test different whitespace patterns."""
         # Extra spaces
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "  MyClass :: method  (  int  )  "
         )
         # Should handle gracefully (may strip whitespace)
@@ -137,66 +153,90 @@ class TestExtractFunctionName:
     def test_anonymous_namespace(self, coverage):
         """Test anonymous namespace (represented as empty in demangled output)."""
         # Anonymous namespaces might appear in various forms
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "(anonymous namespace)::function()"
         )
         assert qualified == "(anonymous namespace)::function"
         assert simple == "function"
+        assert full_name == "(anonymous namespace)::function()"
 
     def test_destructor(self, coverage):
         """Test destructor."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "MyClass::~MyClass()"
         )
         assert "~MyClass" in simple
 
     def test_no_namespace_with_params(self, coverage):
         """Test function with params but no namespace."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "simpleFunc(int, char*)"
         )
         assert qualified == "simpleFunc"
         assert simple == "simpleFunc"
+        assert full_name == "simpleFunc(int, char*)"
 
     def test_static_method(self, coverage):
         """Test static method (looks same as regular method)."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "MyClass::staticMethod()"
         )
         assert qualified == "MyClass::staticMethod"
         assert simple == "staticMethod"
+        assert full_name == "MyClass::staticMethod()"
 
     def test_inline_method(self, coverage):
         """Test inline method."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "MyClass::inlineMethod()"
         )
         assert qualified == "MyClass::inlineMethod"
         assert simple == "inlineMethod"
+        assert full_name == "MyClass::inlineMethod()"
 
     def test_virtual_method(self, coverage):
         """Test virtual method (looks same as regular method after demangling)."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "Base::virtualMethod()"
         )
         assert qualified == "Base::virtualMethod"
         assert simple == "virtualMethod"
+        assert full_name == "Base::virtualMethod()"
 
     def test_deeply_nested(self, coverage):
         """Test deeply nested namespace/class."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "Level1::Level2::Level3::Level4::Level5::deepFunc()"
         )
         assert qualified == "Level1::Level2::Level3::Level4::Level5::deepFunc"
         assert simple == "deepFunc"
+        assert full_name == "Level1::Level2::Level3::Level4::Level5::deepFunc()"
 
     def test_std_library_function(self, coverage):
         """Test standard library function."""
-        qualified, simple = coverage._extract_function_name(
+        qualified, simple, full_name = coverage._extract_function_name(
             "std::cout::operator<<(const char*)"
         )
         assert simple == "operator<<"
         assert "std::cout::operator<<" in qualified
+        assert full_name == "std::cout::operator<<(const char*)"
+
+    def test_overloaded_constructors_differ_by_full_name(self, coverage):
+        """Test that overloaded constructors have the same qualified/simple but different full names."""
+        qualified1, simple1, full1 = coverage._extract_function_name(
+            "Json::PathArgument::PathArgument(char const*)"
+        )
+        qualified2, simple2, full2 = coverage._extract_function_name(
+            "Json::PathArgument::PathArgument(unsigned int)"
+        )
+        # qualified and simple should be the same
+        assert qualified1 == qualified2 == "Json::PathArgument::PathArgument"
+        assert simple1 == simple2 == "PathArgument"
+        # full_name should be different (includes signature)
+        # Signature is normalized: "char const*" -> "const char*"
+        assert full1 == "Json::PathArgument::PathArgument(const char*)"
+        assert full2 == "Json::PathArgument::PathArgument(unsigned int)"
+        assert full1 != full2
 
 
 class TestDemangleCxxNames:


### PR DESCRIPTION
## Problem
ApiCov was simplifying demangled C++ names to just the simple function name, causing overloaded functions like:
  - `Json::PathArgument::PathArgument(char const*)`
  - `Json::PathArgument::PathArgument(unsigned int)` to all become just "PathArgument", overwriting each other's coverage data.

## Solution:
- `_extract_function_name()` now returns 3 values: (qualified, simple, full_name) where full_name includes the signature for unique identification
- `demangle_cxx_names()` preserves full demangled name with signature in gcov logs
- apicov.py builds full_name (qualified + signature) for coverage lookup
- Output JSON now uses full_name as key to distinguish overloaded functions
- C functions: no change (name == simple == full_name)
- Existing C++ data: migration backfills simple_name = name

## Testing done
- All existing tests in ApiCov
- Ask Claude to e2e test the following cases:
  -  Virtual functions
  - Overloaded constructors                                                                                                  
  - Operator overloading                                                                                                 
  - Nested namespaces                                                                                             
  - Multiple inheritance                                                                                                  
  - Static methods                                                                                                 
  - Overloaded free functions     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-aware system include path detection for macOS/Linux.
  * API identifiers now include normalized signatures for reliable disambiguation; documentation lookups still use simple names.

* **Bug Fixes**
  * More robust coverage matching with fallback name searches and demangling that preserves full signatures.
  * Normalized coverage values (NaN → 0, clamped >100%) and consistent mapping between coverage, docs, and JSON (uses signature-inclusive keys).

* **Tests**
  * Updated tests to validate signature-inclusive API keys and normalized name representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->